### PR TITLE
Fix for race between LiteCore Replication and LoopbackProvider

### DIFF
--- a/include/blip_cpp/WebSocketInterface.hh
+++ b/include/blip_cpp/WebSocketInterface.hh
@@ -141,6 +141,8 @@ namespace litecore { namespace websocket {
 
         /** Clears the delegate; any future calls to delegate() will fail. Call after closing. */
         void clearDelegate()                        {_delegate = nullptr;}
+
+        bool hasDelegate() { return _delegate != nullptr; }
         
     private:
         const Address _address;


### PR DESCRIPTION
The mechanism is that is the message for the response is received too early, the same message is rescheduled after an arbitrary delay of 500ms (scheduling with 0 causes thrashing and several dozen "performNextMessage" log messages).  This needs to be done in various places because other mailbox messages assume that the first rescheduled one actually succeeded.

Fixes #2