### PR TITLE
Fixed crashing race condition accessing WebSocketImpl::_pingTimer

### DIFF
--- a/include/blip_cpp/WebSocketImpl.hh
+++ b/include/blip_cpp/WebSocketImpl.hh
@@ -102,7 +102,7 @@ namespace litecore { namespace websocket {
         // Connection diagnostics, logged on close:
         fleece::Stopwatch _timeConnected {false};           // Time since socket opened
         uint64_t _bytesSent {0}, _bytesReceived {0};// Total byte count sent/received
-};
+    };
 
 
     /** Provider implementation that creates WebSocketImpls. */


### PR DESCRIPTION
The `onClose` method was clearing `_pingTimer` without holding the mutex.