### PR TITLE
Fixes LiteCore issue 684 (mailbox race condition)

### DIFF
--- a/src/util/GCDMailbox.cc
+++ b/src/util/GCDMailbox.cc
@@ -123,6 +123,8 @@ namespace litecore { namespace actor {
     }
 
     void GCDMailbox::afterEvent() {
+        _actor->afterEvent();
+        endBusy();
 #if ACTORS_TRACK_STATS
         ++_callCount;
         if (_eventCount > _maxEventCount) {
@@ -130,9 +132,6 @@ namespace litecore { namespace actor {
         }
 #endif
         --_eventCount;
-        
-        _actor->afterEvent();
-        endBusy();
         release(_actor);
     }
 

--- a/src/util/GCDMailbox.cc
+++ b/src/util/GCDMailbox.cc
@@ -97,7 +97,7 @@ namespace litecore { namespace actor {
         retain(_actor);
         auto wrappedBlock = ^{
             endLatency();
-            beforeEvent();
+            beginBusy();
             safelyCall(block);
             afterEvent();
         };
@@ -111,7 +111,7 @@ namespace litecore { namespace actor {
         retain(_actor);
         auto wrappedBlock = ^{
             endLatency();
-            beforeEvent();
+            beginBusy();
             safelyCall(block);
             afterEvent();
         };
@@ -122,8 +122,7 @@ namespace litecore { namespace actor {
             dispatch_async(_queue, wrappedBlock);
     }
 
-    void GCDMailbox::beforeEvent() {
-        beginBusy();
+    void GCDMailbox::afterEvent() {
 #if ACTORS_TRACK_STATS
         ++_callCount;
         if (_eventCount > _maxEventCount) {
@@ -131,9 +130,7 @@ namespace litecore { namespace actor {
         }
 #endif
         --_eventCount;
-    }
-
-    void GCDMailbox::afterEvent() {
+        
         _actor->afterEvent();
         endBusy();
         release(_actor);

--- a/src/util/GCDMailbox.cc
+++ b/src/util/GCDMailbox.cc
@@ -82,7 +82,7 @@ namespace litecore { namespace actor {
     }
 
 
-    void GCDMailbox::safelyCall(void (^block)()) {
+    void GCDMailbox::safelyCall(void (^block)()) const {
         try {
             block();
         } catch (const std::exception &x) {
@@ -97,7 +97,7 @@ namespace litecore { namespace actor {
         retain(_actor);
         auto wrappedBlock = ^{
             endLatency();
-            beginBusy();
+            beforeEvent();
             safelyCall(block);
             afterEvent();
         };
@@ -111,7 +111,7 @@ namespace litecore { namespace actor {
         retain(_actor);
         auto wrappedBlock = ^{
             endLatency();
-            beginBusy();
+            beforeEvent();
             safelyCall(block);
             afterEvent();
         };
@@ -122,10 +122,8 @@ namespace litecore { namespace actor {
             dispatch_async(_queue, wrappedBlock);
     }
 
-
-    void GCDMailbox::afterEvent() {
-        _actor->afterEvent();
-        endBusy();
+    void GCDMailbox::beforeEvent() {
+        beginBusy();
 #if ACTORS_TRACK_STATS
         ++_callCount;
         if (_eventCount > _maxEventCount) {
@@ -133,11 +131,16 @@ namespace litecore { namespace actor {
         }
 #endif
         --_eventCount;
+    }
+
+    void GCDMailbox::afterEvent() {
+        _actor->afterEvent();
+        endBusy();
         release(_actor);
     }
 
 
-    void GCDMailbox::logStats() {
+    void GCDMailbox::logStats() const {
 #if ACTORS_TRACK_STATS
         LogTo(ActorLog, "%s handled %d events; max queue depth was %d; max latency was %s; busy %s (%.1f%%)",
               _actor->actorName().c_str(), _callCount, _maxEventCount,

--- a/src/util/GCDMailbox.hh
+++ b/src/util/GCDMailbox.hh
@@ -46,14 +46,15 @@ namespace litecore { namespace actor {
 
         static void startScheduler(Scheduler *)             { }
 
-        void logStats();
+        void logStats() const;
 
         static Actor* currentActor();
 
     private:
         void runEvent(void (^block)());
         void afterEvent();
-        void safelyCall(void (^block)());
+        void beforeEvent();
+        void safelyCall(void (^block)()) const;
         
         Actor *_actor;
         dispatch_queue_t _queue;

--- a/src/util/GCDMailbox.hh
+++ b/src/util/GCDMailbox.hh
@@ -53,7 +53,6 @@ namespace litecore { namespace actor {
     private:
         void runEvent(void (^block)());
         void afterEvent();
-        void beforeEvent();
         void safelyCall(void (^block)()) const;
         
         Actor *_actor;

--- a/src/util/ThreadedMailbox.cc
+++ b/src/util/ThreadedMailbox.cc
@@ -186,6 +186,13 @@ namespace litecore { namespace actor {
         }
 #endif
 
+        // This needs to happen *before* the actor's afterEvent call because this flow
+        // needs to be protected:
+        // 1. enqueueAfter increments _delayedEventCount (eventCount() = 1)
+        // 2. After the delay, enqueueAfter calls enqueue (eventCount() = 2)
+        // 3. _delayedEventCount needs to be decremented to give the correct value
+        //    of eventCount() = 1 during the actor's afterEvent
+        // This has to be on the same thread as the mailbox so no races occur
         if(wasDelayed) {
             --_delayedEventCount;
         }

--- a/src/util/ThreadedMailbox.hh
+++ b/src/util/ThreadedMailbox.hh
@@ -68,8 +68,7 @@ namespace litecore { namespace actor {
         
         void reschedule();
         void performNextMessage();
-        void beforeEvent(bool);
-        void afterEvent();
+        void afterEvent(bool);
         void safelyCall(const std::function<void()> &f) const;
 
         Actor* const _actor;


### PR DESCRIPTION
Until now a race has existed between when the event count is decremented after a call to enqueue and the logic of enqueue being executed.  This meant there was the potential for an actor to get into a false busy state and behave badly.  In particular a replicator would never inform its delegate that it had stopped.