### PR TITLE
Include app defined errors

### DIFF
--- a/include/blip_cpp/WebSocketInterface.hh
+++ b/include/blip_cpp/WebSocketInterface.hh
@@ -56,6 +56,8 @@ namespace litecore { namespace websocket {
         kCodeExtensionNotNegotiated,
         kCodeUnexpectedCondition,
         kCodeFailedTLSHandshake = 1015,
+        kCloseAppTransient = 4001,          // App-defined transient error
+        kCloseAppPermanent,                 // App-defined permanent error
     };
 
     enum NetworkError {


### PR DESCRIPTION
Include App defined error in sync with C4Socket errors.

ref: https://github.com/couchbase/couchbase-lite-core/pull/924
ref comment: https://github.com/couchbase/couchbase-lite-core/pull/924#discussion_r385428523